### PR TITLE
remove useless greenfield bsc testnet and update RPC

### DIFF
--- a/utils/chains.json
+++ b/utils/chains.json
@@ -223,40 +223,11 @@
     ]
   },
   {
-    "name": "Greenfield BSC Testnet",
-    "chain": "BSC",
-    "rpc": [
-      "https://gnfd-bsc-testnet-dataseed1.bnbchain.org",
-      "https://gnfd-bsc-testnet-dataseed2.bnbchain.org",
-      "https://greenfield-bsc-testnet-ap.nodereal.io",
-      "https://greenfield-bsc-testnet-us.nodereal.io"
-    ],
-    "faucets": [
-      "https://gnfd-bsc-faucet.bnbchain.org/"
-    ],
-    "nativeCurrency": {
-      "name": "BNB Chain Native Token",
-      "symbol": "tBNB",
-      "decimals": 18
-    },
-    "infoURL": "https://bnbchain.org/en/greenfield",
-    "chainId": 5601,
-    "explorers": [
-      {
-        "name": "Greenfield BSC Testnet Blockchain Explorer",
-        "url": "https://greenfield-bsc-testnet-explorer.nodereal.io/",
-        "standard": "EIP3091"
-      }
-    ]
-  },
-  {
-    "name": "Greenfield Blockchain Testnet",
+    "name": "Greenfield Mekong Testnet",
     "chain": "GNFD",
     "rpc": [
-      "https://gnfd-testnet-ethapi-us.bnbchain.org"
-    ],
-    "faucets": [
-      "https://gnfd-bsc-faucet.bnbchain.org/"
+      "https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org",
+      "https://gnfd-testnet-fullnode-tendermint-us.nodereal.io"
     ],
     "nativeCurrency": {
       "name": "BNB Chain Native Token",


### PR DESCRIPTION
Please check the release note of greenfield: https://greenfield.bnbchain.org/docs/release-notes/#greenfield-v0-2-1-mekong-testnet-reset

🔸The Greenfield BSC Testnet (Chain ID: 5601) will be discontinued. Instead, we'll deploy the Greenfield Cross-Chain contracts on the BSC Chapel Testnet (Chain ID: 97). This means you can fully utilize all the infrastructure of the current BSC Chapel Testnet, such as bscscan, tenderly, theGraph, and so on. BNB and Greenfield resources can still flow freely between Greenfield testnet and BSC testnet.

